### PR TITLE
fix var name classname

### DIFF
--- a/src/wrapper-mysql.php
+++ b/src/wrapper-mysql.php
@@ -754,9 +754,9 @@ if ( ! function_exists ('mysql_connect') ) {
                     );
                     return false;
                 }
-                $r = mysqli_fetch_object ($result, $calassname, $params);
+                $r = mysqli_fetch_object ($result, $classname, $params);
             } else
-                $r = mysqli_fetch_object ($result, $calassname);
+                $r = mysqli_fetch_object ($result, $classname);
         } else
             $r = mysqli_fetch_object ($result);
 


### PR DESCRIPTION
I encountered a bug using the library. I hope I can contribute. Var name is incorrect.